### PR TITLE
Update: adjust card's RWD size setting

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -22,7 +22,7 @@ export const Card = memo(({ pokemon }: CardProps) => {
         hidden: !pokemon.display,
       })}
     >
-      <button onClick={handleClick}>
+      <button className='w-full' onClick={handleClick}>
         <Header paldeaId={pokemon.paldeaId} name={pokemon.nameZh} link={pokemon.link} />
         <Body pokemon={pokemon} />
 

--- a/src/components/Card/Header.tsx
+++ b/src/components/Card/Header.tsx
@@ -12,12 +12,13 @@ export function Header({ paldeaId, name, link }: HeaderProps) {
       className={clsx(
         'flex flex-col-reverse items-center justify-center',
         'md:flex-row md:items-end md:justify-between',
-        '-mb-8 px-3 md:px-4'
+        'min-h-[83px] md:min-h-[148px]',
+        '-mb-8 px-3 md:px-4',
       )}
     >
       <span className="hidden whitespace-nowrap leading-none md:block">{`#${paldeaId}`}</span>
       <img
-        className="min-h-[83px] md:min-h-[148px]"
+        className="h-full w-auto"
         src={`${process.env.PUBLIC_URL}/image/icon/${link}.png`}
         alt={name}
         loading="lazy"


### PR DESCRIPTION
情況：
在圖片下載完成之前，卡片會因為沒有圖片撐開高度而壓扁在一起

解決方式：
將最小高度的設定移動到圖片的 container，而圖片的顯示則是以填滿高度為主